### PR TITLE
Added cleancache

### DIFF
--- a/commands/cleancache/README.md
+++ b/commands/cleancache/README.md
@@ -4,6 +4,12 @@
 
 Clean the package manager cache, free not-that-necessary system space
 
+## Syntax
+Simply type in terminal:
+```bash
+cleancache
+```
+
 ## Features
 
 <ul>
@@ -16,9 +22,4 @@ Run the installer.sh script to install the command
 
 ```bash
 bash installer.sh
-```
-## To use the command
-Simply type in terminal:
-```bash
-cleancache
 ```

--- a/commands/cleancache/README.md
+++ b/commands/cleancache/README.md
@@ -13,3 +13,12 @@ Clean the package manager cache, free not-that-necessary system space
 
 ## How to install
 Run the installer.sh script to install the command
+
+```bash
+bash installer.sh
+```
+## To use the command
+Simply type in terminal:
+```bash
+cleancache
+```

--- a/commands/cleancache/README.md
+++ b/commands/cleancache/README.md
@@ -1,0 +1,15 @@
+# cleancache
+
+## Description
+
+Clean the package manager cache, free not-that-necessary system space
+
+## Features
+
+<ul>
+<li>Cleans the package manager cache</li>
+<li>Works on many distributions</li>
+</ul>
+
+## How to install
+Run the installer.sh script to install the command

--- a/commands/cleancache/cleancache
+++ b/commands/cleancache/cleancache
@@ -1,0 +1,19 @@
+#!/bin/bash
+source /etc/os-release
+
+# <------- DEBUG STATEMENTS ------->
+# cat /etc/os-release
+
+if [[ "$ID" == *"arch"* ]] || [[ "$ID_LIKE" == *"arch"* ]]; then
+	sudo pacman -Scc 
+elif [[ "$ID" == *"debian"* ]] || [[ "$ID_LIKE" == *"debian"* ]] || [[ "$ID" == *"ubuntu"* ]]; then
+	sudo apt clean
+elif [[ "$ID" == *"fedora"* ]] || [[ "$ID_LIKE" == *"fedora"* ]]; then
+	sudo dnf clean all
+elif [[ "$ID" == *"suse"* ]] || [[ "$ID_LIKE" == *"suse"* ]]; then
+	sudo zypper clean
+elif [[ "$ID" == *"gentoo"* ]] || [[ "$ID_LIKE" == *"gentoo"* ]]; then
+	sudo emerge --clean
+elif [[ "$ID" == *"slackware"* ]] || [[ "$ID_LIKE" == *"slackware"* ]]; then
+	sudo slackpkg clean 
+fi

--- a/commands/cleancache/installer.sh
+++ b/commands/cleancache/installer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Copies the command to appropriate location
+sudo cp cleancache /usr/local/bin


### PR DESCRIPTION
The command cleans the package manager cache, and works on multiple Linux distributions.
 
Script Implementation:

* [`commands/cleancache/cleancache`](diffhunk://#diff-2b98cad9315e5296fee054a84c9c4a291a12ea08cc827d19fa0c4325d52dce40R1-R19): Added the `cleancache` script that detects the Linux distribution and runs the appropriate package manager clean command.

Installation Script:

* [`commands/cleancache/installer.sh`](diffhunk://#diff-27d6d676461f2b5c98b3fc49354a53d40b4229e9c7e980675969c90412c530deR1-R4): Added an installer script to copy the `cleancache` command to `/usr/local/bin`.